### PR TITLE
:sparkles: Support mouse check passing through components

### DIFF
--- a/Bearded.UI/Controls/Control.cs
+++ b/Bearded.UI/Controls/Control.cs
@@ -38,6 +38,8 @@ namespace Bearded.UI.Controls
             }
         }
 
+        public bool IsClickThrough { get; protected set; }
+
         public bool IsFocused { get; private set; }
         public bool CanBeFocused { get; protected set; }
 
@@ -69,7 +71,7 @@ namespace Bearded.UI.Controls
 
             return IsFocused;
         }
-      
+
         public void SetAnchors(HorizontalAnchors horizontal, VerticalAnchors vertical)
         {
             HorizontalAnchors = horizontal;
@@ -90,7 +92,7 @@ namespace Bearded.UI.Controls
         {
             frameNeedsUpdate = true;
         }
-        
+
         private Frame getFrame()
         {
             if (frameNeedsUpdate)
@@ -115,7 +117,7 @@ namespace Bearded.UI.Controls
         }
 
         public void RemoveFromParent() => Parent.Remove(this);
-        
+
         internal void AddTo(IControlParent parent)
         {
             if (Parent != null)
@@ -135,12 +137,12 @@ namespace Bearded.UI.Controls
 
             Parent = null;
         }
-        
+
         public virtual void Render(IRendererRouter r)
         {
             RenderStronglyTyped(r);
         }
-  
+
         protected abstract void RenderStronglyTyped(IRendererRouter r);
 
         public event GenericEventHandler<MouseEventArgs> MouseEnter;
@@ -193,7 +195,7 @@ namespace Bearded.UI.Controls
 
         protected virtual void MadeVisible() { } // Not called on initialization
         protected virtual void MadeInvisible() { }
-        
+
         protected virtual void OnAddingToParent() { }
         protected virtual void OnRemovingFromParent() { }
     }

--- a/Bearded.UI/Events/EventRouter.cs
+++ b/Bearded.UI/Events/EventRouter.cs
@@ -10,9 +10,9 @@ namespace Bearded.UI.Events
     {
         public enum PropagationTestOutcome
         {
-            Failure,
+            Miss,
             PassThrough,
-            Success
+            Hit
         }
 
         public delegate void RoutedEvent<in T>(Control control, T eventData) where T : RoutedEventArgs;
@@ -54,7 +54,7 @@ namespace Bearded.UI.Events
                 var outcome = propagationTest(child);
                 switch (outcome)
                 {
-                    case PropagationTestOutcome.Failure:
+                    case PropagationTestOutcome.Miss:
                         continue;
                     case PropagationTestOutcome.PassThrough:
                         if (!(child is IControlParent childAsParent) || childAsParent.Children.Count == 0)
@@ -73,7 +73,7 @@ namespace Bearded.UI.Events
                             yield return descendant;
                         }
                         break;
-                    case PropagationTestOutcome.Success:
+                    case PropagationTestOutcome.Hit:
                         yield return child;
                         foreach (
                             var descendant in findPropagationPathEnumerable(child as IControlParent, propagationTest))

--- a/Bearded.UI/Events/EventRouter.cs
+++ b/Bearded.UI/Events/EventRouter.cs
@@ -8,25 +8,19 @@ namespace Bearded.UI.Events
 {
     static class EventRouter
     {
-        public delegate void RoutedEvent<in T>(Control control, T eventData) where T : RoutedEventArgs;
-
-        public static EventPropagationPath FindPropagationPath(IControlParent root, Predicate<Control> childSelector)
+        public enum PropagationTestOutcome
         {
-            var parent = root;
-            var path = new List<Control>();
+            Failure,
+            PassThrough,
+            Success
+        }
 
-            while (parent != null)
-            {
-                var child = parent.Children.Reverse().FirstOrDefault(childSelector.Invoke);
-                if (child != null)
-                {
-                    path.Add(child);
-                }
+        public delegate void RoutedEvent<in T>(Control control, T eventData) where T : RoutedEventArgs;
+        public delegate PropagationTestOutcome PropagationTest(Control control);
 
-                parent = child as IControlParent;
-            }
-
-            return new EventPropagationPath(path.AsReadOnly());
+        public static EventPropagationPath FindPropagationPath(IControlParent root, PropagationTest propagationTest)
+        {
+            return new EventPropagationPath(findPropagationPathEnumerable(root, propagationTest).ToList().AsReadOnly());
         }
 
         public static EventPropagationPath FindPropagationPath(IControlParent root, Control leaf)
@@ -42,12 +36,55 @@ namespace Bearded.UI.Events
                     return EventPropagationPath.Empty;
                 }
                 path.Add(parentAsControl);
-                
+
                 parent = parentAsControl.Parent;
             }
 
             path.Reverse();
             return new EventPropagationPath(path.AsReadOnly());
+        }
+
+        private static IEnumerable<Control> findPropagationPathEnumerable(
+            IControlParent root, PropagationTest propagationTest)
+        {
+            if (root == null) yield break;
+
+            foreach (var child in root.Children.Reverse())
+            {
+                var outcome = propagationTest(child);
+                switch (outcome)
+                {
+                    case PropagationTestOutcome.Failure:
+                        continue;
+                    case PropagationTestOutcome.PassThrough:
+                        if (!(child is IControlParent childAsParent) || childAsParent.Children.Count == 0)
+                        {
+                            continue;
+                        }
+                        var potentialPath = findPropagationPathEnumerable(childAsParent, propagationTest).ToList();
+                        if (potentialPath.Count == 0
+                            || propagationTest(potentialPath.Last()) == PropagationTestOutcome.PassThrough)
+                        {
+                            continue;
+                        }
+                        yield return child;
+                        foreach (var descendant in potentialPath)
+                        {
+                            yield return descendant;
+                        }
+                        break;
+                    case PropagationTestOutcome.Success:
+                        yield return child;
+                        foreach (
+                            var descendant in findPropagationPathEnumerable(child as IControlParent, propagationTest))
+                        {
+                            yield return descendant;
+                        }
+                        yield break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
         }
     }
 }

--- a/Bearded.UI/Events/MouseEventManager.cs
+++ b/Bearded.UI/Events/MouseEventManager.cs
@@ -31,7 +31,17 @@ namespace Bearded.UI.Events
             var mousePosition = root.TransformViewportPosToFramePos((Vector2d) inputManager.MousePosition);
 
             var path = EventRouter.FindPropagationPath(
-                root, control => control.IsVisible &&  control.Frame.ContainsPoint(mousePosition));
+                root, control =>
+                {
+                    if (!control.IsVisible || !control.Frame.ContainsPoint(mousePosition))
+                    {
+                        return EventRouter.PropagationTestOutcome.Failure;
+                    }
+
+                    return control.IsClickThrough
+                        ? EventRouter.PropagationTestOutcome.PassThrough
+                        : EventRouter.PropagationTestOutcome.Success;
+                });
 
             var (removedFromPath, addedToPath) = previousPropagationPath != null
                 ? EventPropagationPath.CalculateDeviation(previousPropagationPath, path)

--- a/Bearded.UI/Events/MouseEventManager.cs
+++ b/Bearded.UI/Events/MouseEventManager.cs
@@ -35,12 +35,12 @@ namespace Bearded.UI.Events
                 {
                     if (!control.IsVisible || !control.Frame.ContainsPoint(mousePosition))
                     {
-                        return EventRouter.PropagationTestOutcome.Failure;
+                        return EventRouter.PropagationTestOutcome.Miss;
                     }
 
                     return control.IsClickThrough
                         ? EventRouter.PropagationTestOutcome.PassThrough
-                        : EventRouter.PropagationTestOutcome.Success;
+                        : EventRouter.PropagationTestOutcome.Hit;
                 });
 
             var (removedFromPath, addedToPath) = previousPropagationPath != null


### PR DESCRIPTION
This is achieved in the following way:

* Instead of the propagation test having a boolean outcome, it can now have three outcomes: failure, success, and pass through.
* Failure and success are at before. In the case of mouse events, it means that the cursor is in the bounding box and not respectively.
* Pass through means that the control is ignored, and the children are considered instead. If any of the descendants passes the propagation test, the path propagates down, otherwise it doesn't.

I feel as if the implementation is fairly complex, but it was still the simplest I could think of. I am open to suggestions for different approaches.

Sadly we don't have any tests to verify this behaviour. As setting up tests would involve mocking the input manager, I think we may be better off saving that for a separate PR.

Closes #8.