### PR TITLE
✨ Add modifier keys to event args

### DIFF
--- a/Bearded.UI/EventArgs/KeyEventArgs.cs
+++ b/Bearded.UI/EventArgs/KeyEventArgs.cs
@@ -5,10 +5,12 @@ namespace Bearded.UI.EventArgs
     public class KeyEventArgs : RoutedEventArgs
     {
         public Key Key { get; }
+        public ModifierKeys ModifierKeys { get; }
 
-        public KeyEventArgs(Key key)
+        public KeyEventArgs(Key key, ModifierKeys modifierKeys)
         {
             Key = key;
+            ModifierKeys = modifierKeys;
         }
     }
 }

--- a/Bearded.UI/EventArgs/ModifierKeys.cs
+++ b/Bearded.UI/EventArgs/ModifierKeys.cs
@@ -1,0 +1,30 @@
+using Bearded.Utilities.Input;
+using OpenTK.Input;
+
+namespace Bearded.UI.EventArgs
+{
+    public sealed class ModifierKeys
+    {
+        public bool Shift { get; }
+        public bool Control { get; }
+        public bool Alt { get; }
+        public bool Win { get; }
+
+        private ModifierKeys(bool shift, bool control, bool alt, bool win)
+        {
+            Shift = shift;
+            Control = control;
+            Alt = alt;
+            Win = win;
+        }
+
+        public static ModifierKeys FromInputManager(InputManager inputManager)
+        {
+            return new ModifierKeys(
+                inputManager.IsKeyPressed(Key.LShift) || inputManager.IsKeyPressed(Key.RShift),
+                inputManager.IsKeyPressed(Key.LControl) || inputManager.IsKeyPressed(Key.RControl),
+                inputManager.IsKeyPressed(Key.LAlt) || inputManager.IsKeyPressed(Key.RAlt),
+                inputManager.IsKeyPressed(Key.LWin) || inputManager.IsKeyPressed(Key.RWin));
+        }
+    }
+}

--- a/Bearded.UI/EventArgs/MouseButtonEventArgs.cs
+++ b/Bearded.UI/EventArgs/MouseButtonEventArgs.cs
@@ -7,7 +7,8 @@ namespace Bearded.UI.EventArgs
     {
         public MouseButton MouseButton { get; }
 
-        public MouseButtonEventArgs(Vector2d mousePosition, MouseButton mouseButton) : base(mousePosition)
+        public MouseButtonEventArgs(Vector2d mousePosition, ModifierKeys modifierKeys, MouseButton mouseButton)
+            : base(mousePosition, modifierKeys)
         {
             MouseButton = mouseButton;
         }

--- a/Bearded.UI/EventArgs/MouseEventArgs.cs
+++ b/Bearded.UI/EventArgs/MouseEventArgs.cs
@@ -5,10 +5,12 @@ namespace Bearded.UI.EventArgs
     public class MouseEventArgs : RoutedEventArgs
     {
         public Vector2d MousePosition { get; }
+        public ModifierKeys ModifierKeys { get; }
 
-        public MouseEventArgs(Vector2d mousePosition)
+        public MouseEventArgs(Vector2d mousePosition, ModifierKeys modifierKeys)
         {
             MousePosition = mousePosition;
+            ModifierKeys = modifierKeys;
         }
     }
 }

--- a/Bearded.UI/EventArgs/MouseScrollEventArgs.cs
+++ b/Bearded.UI/EventArgs/MouseScrollEventArgs.cs
@@ -7,8 +7,9 @@ namespace Bearded.UI.EventArgs
         public int DeltaScroll { get; }
         public float DeltaScrollF { get; }
 
-        public MouseScrollEventArgs(Vector2d mousePosition, int deltaScroll, float deltaScrollF)
-            : base(mousePosition)
+        public MouseScrollEventArgs(
+            Vector2d mousePosition, ModifierKeys modifierKeys, int deltaScroll, float deltaScrollF)
+            : base(mousePosition, modifierKeys)
         {
             DeltaScroll = deltaScroll;
             DeltaScrollF = deltaScrollF;

--- a/Bearded.UI/Events/KeyboardEventManager.cs
+++ b/Bearded.UI/Events/KeyboardEventManager.cs
@@ -28,9 +28,11 @@ namespace Bearded.UI.Events
                 ? EventPropagationPath.Empty
                 : EventRouter.FindPropagationPath(root, focusedControl);
 
+            var modifierKeys = ModifierKeys.FromInputManager(inputManager);
+
             foreach (var (eventArgs, isPressed) in inputManager.KeyEvents)
             {
-                var args = new KeyEventArgs(eventArgs.Key);
+                var args = new KeyEventArgs(eventArgs.Key, modifierKeys);
 
                 if (isPressed)
                 {

--- a/Bearded.UI/Events/MouseEventManager.cs
+++ b/Bearded.UI/Events/MouseEventManager.cs
@@ -29,6 +29,7 @@ namespace Bearded.UI.Events
         internal void Update()
         {
             var mousePosition = root.TransformViewportPosToFramePos((Vector2d) inputManager.MousePosition);
+            var modifierKeys = ModifierKeys.FromInputManager(inputManager);
 
             var path = EventRouter.FindPropagationPath(
                 root, control => control.IsVisible &&  control.Frame.ContainsPoint(mousePosition));
@@ -36,7 +37,7 @@ namespace Bearded.UI.Events
             var (removedFromPath, addedToPath) = previousPropagationPath != null
                 ? EventPropagationPath.CalculateDeviation(previousPropagationPath, path)
                 : (EventPropagationPath.Empty, path);
-            var eventArgs = new MouseEventArgs(mousePosition);
+            var eventArgs = new MouseEventArgs(mousePosition, modifierKeys);
 
             // Mouse exit
             removedFromPath.PropagateEvent(
@@ -63,14 +64,14 @@ namespace Bearded.UI.Events
                 if (action.Hit)
                 {
                     path.PropagateEvent(
-                        new MouseButtonEventArgs(mousePosition, btn),
+                        new MouseButtonEventArgs(mousePosition, modifierKeys, btn),
                         (c, e) => c.PreviewMouseButtonHit(e),
                         (c, e) => c.MouseButtonHit(e));
                 }
                 if (action.Released)
                 {
                     path.PropagateEvent(
-                        new MouseButtonEventArgs(mousePosition, btn),
+                        new MouseButtonEventArgs(mousePosition, modifierKeys, btn),
                         (c, e) => c.PreviewMouseButtonReleased(e),
                         (c, e) => c.MouseButtonReleased(e));
                 }
@@ -81,7 +82,8 @@ namespace Bearded.UI.Events
             if (inputManager.DeltaScrollF != 0)
             {
                 path.PropagateEvent(
-                    new MouseScrollEventArgs(mousePosition, inputManager.DeltaScroll, inputManager.DeltaScrollF),
+                    new MouseScrollEventArgs(
+                        mousePosition, modifierKeys, inputManager.DeltaScroll, inputManager.DeltaScrollF),
                     (c, e) => c.PreviewMouseScrolled(e),
                     (c, e) => c.MouseScrolled(e));
             }


### PR DESCRIPTION
## ✨ What's this?
This PR adds a small object that contains the status of the four most common modifier keys (shift, control, alt, and win) to the mouse and keyboard event args, and populates these for all existing events.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
Right now the UI framework is completely reactive, meaning that controls only get notified when a key is pressed or mouse button clicked. This makes it really hard for them to know whether a button is currently held down. This prevents implementing functionality that relies on shortcuts such as ctrl-c and ctrl-v, or shift-clicking something without having to rely on querying the input manager itself.

By adding the most common modifier keys to the event args, which has an almost negligible cost, we can definitely solve the 90% use case.

## 🏗 How is it done?
A new object `ModifierKeys` is added in the `EventArgs` namespace that knows how to build itself from an input manager. This object is created once for each of the two event managers (mouse and keyboard) and passed as one of the fields in the event args.

The modifier keys are queried directly from the `InputManager`.

### 💥 Breaking changes
* [trivial] The new type will clash with any other already imported types named `ModifierKeys`.

### 🔬 Why not another way?
* Make `ModifierKeys` a flags enum and use extension methods for the direct access properties. This seems overengineering, given that it is unlikely we ever need functionality beyond the current.
* Make `ModifierKeys` a struct: all other event args types are classes, so it felt like it made sense to follow that. Using a class also means we can forbid creation of this object outside of the static 

### 🦋 Side effects
N/A

## 💡 Review hints
Should be a fairly trivial change. The most important thing is to validate the chosen approach (see arguments above).

Adding tests is blocked by #11 being approved and merged.