### PR TITLE
🔍 Support IsClickThrough for ListControl

### DIFF
--- a/Bearded.UI/Controls/CompositeControl.cs
+++ b/Bearded.UI/Controls/CompositeControl.cs
@@ -17,7 +17,7 @@ namespace Bearded.UI.Controls
             Children = children.AsReadOnly();
         }
 
-        public static CompositeControl ClickThrough() => new CompositeControl {IsClickThrough = true};
+        public static CompositeControl CreateClickThrough() => new CompositeControl {IsClickThrough = true};
 
         public void Add(Control child)
         {

--- a/Bearded.UI/Controls/CompositeControl.cs
+++ b/Bearded.UI/Controls/CompositeControl.cs
@@ -17,6 +17,8 @@ namespace Bearded.UI.Controls
             Children = children.AsReadOnly();
         }
 
+        public static CompositeControl ClickThrough() => new CompositeControl {IsClickThrough = true};
+
         public void Add(Control child)
         {
             child.AddTo(this);

--- a/Bearded.UI/Controls/Control.cs
+++ b/Bearded.UI/Controls/Control.cs
@@ -38,7 +38,7 @@ namespace Bearded.UI.Controls
             }
         }
 
-        public bool IsClickThrough { get; protected set; }
+        public virtual bool IsClickThrough { get; set; }
 
         public bool IsFocused { get; private set; }
         public bool CanBeFocused { get; protected set; }

--- a/Bearded.UI/Controls/Control.cs
+++ b/Bearded.UI/Controls/Control.cs
@@ -38,7 +38,7 @@ namespace Bearded.UI.Controls
             }
         }
 
-        public virtual bool IsClickThrough { get; set; }
+        public bool IsClickThrough { get; protected set; }
 
         public bool IsFocused { get; private set; }
         public bool CanBeFocused { get; protected set; }

--- a/Bearded.UI/Controls/implementations/ListControl.cs
+++ b/Bearded.UI/Controls/implementations/ListControl.cs
@@ -70,27 +70,21 @@ namespace Bearded.UI.Controls
             }
         }
 
-        private bool isClickThrough;
-
-        public override bool IsClickThrough
-        {
-            get => isClickThrough;
-            set
-            {
-                isClickThrough = value;
-                listContainer.IsClickThrough = true;
-                contentContainer.IsClickThrough = true;
-            }
-        }
+        public static ListControl ClickThrough(
+                CompositeControl listContainer = null, bool startStuckToBottom = false) =>
+            new ListControl(
+                listContainer ?? CompositeControl.ClickThrough(), CompositeControl.ClickThrough(), startStuckToBottom);
 
         public ListControl(CompositeControl listContainer = null, bool startStuckToBottom = false)
+            : this(listContainer ?? new CompositeControl(), new CompositeControl(), startStuckToBottom) {}
+
+        private ListControl(CompositeControl listContainer, CompositeControl contentContainer, bool startStuckToBottom)
         {
             this.listContainer = listContainer ?? new CompositeControl();
             CurrentlyStuckToBottom = startStuckToBottom;
 
             Add(this.listContainer);
 
-            contentContainer = new CompositeControl();
             this.listContainer.Add(contentContainer);
         }
 

--- a/Bearded.UI/Controls/implementations/ListControl.cs
+++ b/Bearded.UI/Controls/implementations/ListControl.cs
@@ -9,7 +9,7 @@ namespace Bearded.UI.Controls
 {
     // TODO: fix scrolloffset - validateScolloffset recursion
     // TODO: extract scroll controls
-    // TODO: make scoll bar
+    // TODO: make scroll bar
     // TODO: allow insert/removal/update of ranges
     // TODO: refactor all control operations to only happen on frame updates to prevent crashes when calling methods early
 
@@ -67,6 +67,19 @@ namespace Bearded.UI.Controls
                 itemSource = value ?? throw new ArgumentNullException();
                 needsReload = true;
                 SetFrameNeedsUpdateIfNeeded();
+            }
+        }
+
+        private bool isClickThrough;
+
+        public override bool IsClickThrough
+        {
+            get => isClickThrough;
+            set
+            {
+                isClickThrough = value;
+                listContainer.IsClickThrough = true;
+                contentContainer.IsClickThrough = true;
             }
         }
 
@@ -128,7 +141,7 @@ namespace Bearded.UI.Controls
             addCellsDownwards();
             removeCellsDownwards();
         }
-        
+
         public void OnAppendItems(int addedCount)
         {
             if (needsReload)
@@ -204,7 +217,7 @@ namespace Bearded.UI.Controls
                 addCellsUpwards();
             }
         }
-        
+
         public void Reload()
         {
             itemCount = itemSource.ItemCount;
@@ -265,10 +278,10 @@ namespace Bearded.UI.Controls
             while (cells.Count > 0)
             {
                 var lastCell = cells.Last.Value;
-                
+
                 if (lastCell.Offset < contentBottomLimit)
                     break;
-                
+
                 itemSource.DestroyItemControlAt(lastCell.Index, lastCell.Control);
 
                 contentContainer.Remove(lastCell.Control);
@@ -356,7 +369,7 @@ namespace Bearded.UI.Controls
             createCellIfVisible(int index, double bottom, double top, double height)
         {
             var isVisible = bottom >= contentTopLimit && top <= contentBottomLimit;
-            
+
             return isVisible
                 ? (createCellControl(index, top, bottom), index, top, height)
                 : (null, index, top, height);

--- a/Bearded.UI/Controls/implementations/ListControl.cs
+++ b/Bearded.UI/Controls/implementations/ListControl.cs
@@ -70,10 +70,10 @@ namespace Bearded.UI.Controls
             }
         }
 
-        public static ListControl ClickThrough(
+        public static ListControl CreateClickThrough(
                 CompositeControl listContainer = null, bool startStuckToBottom = false) =>
             new ListControl(
-                listContainer ?? CompositeControl.ClickThrough(), CompositeControl.ClickThrough(), startStuckToBottom);
+                listContainer ?? CompositeControl.CreateClickThrough(), CompositeControl.CreateClickThrough(), startStuckToBottom);
 
         public ListControl(CompositeControl listContainer = null, bool startStuckToBottom = false)
             : this(listContainer ?? new CompositeControl(), new CompositeControl(), startStuckToBottom) {}


### PR DESCRIPTION
## ✨ What's this?
This PR adds support for setting `IsClickThrough` on `ListControl`. To do so, it adds static factories to `ListControl` and `CompositeControl` that instantiate a click-through instance of them.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
Lists may have a dynamic length. Clicks shouldn't necessarily be captured by the list wrapper.

## 🏗 How is it done?
`ListControl` and `CompositeControl` have static factories added that create click-through versions of them. These can be used to make a click-through list control.

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
I tried creating a `ClickThroughListControl` subclass, but sadly it can't access both of the wrapper components. I could make those exposed of course, but I don't think `ListControl` is really designed to be extended, so I wanted to take a more generalised approach, and this seemed to be the most inline with the style of the library.

I also attempted to make `IsClickThrough` public on `Control`. This would work, but would set a dangerous precedent.

### 🦋 Side effects
N/A

## 💡 Review hints
Should be a trivial change.