### PR TITLE
✨ Change Button Clicked event to have event args

### DIFF
--- a/Bearded.UI/Controls/implementations/Button.cs
+++ b/Bearded.UI/Controls/implementations/Button.cs
@@ -1,4 +1,6 @@
-﻿using Bearded.UI.Rendering;
+﻿using System;
+using Bearded.UI.EventArgs;
+using Bearded.UI.Rendering;
 using Bearded.Utilities;
 using OpenTK.Input;
 using MouseButtonEventArgs = Bearded.UI.EventArgs.MouseButtonEventArgs;
@@ -7,7 +9,10 @@ namespace Bearded.UI.Controls
 {
     public class Button : CompositeControl
     {
+        [Obsolete("Use #Triggered instead.")]
         public event VoidEventHandler Clicked;
+
+        public event GenericEventHandler<TriggerEventArgs> Triggered;
 
         public bool IsEnabled { get; set; } = true;
 
@@ -21,11 +26,22 @@ namespace Bearded.UI.Controls
             base.MouseButtonReleased(eventArgs);
             if (eventArgs.MouseButton == MouseButton.Left && IsEnabled)
             {
+                Triggered?.Invoke(new TriggerEventArgs(eventArgs.ModifierKeys));
                 Clicked?.Invoke();
             }
             eventArgs.Handled = true;
         }
 
         protected override void RenderStronglyTyped(IRendererRouter r) => r.Render(this);
+
+        public struct TriggerEventArgs
+        {
+            public ModifierKeys ModifierKeys { get; }
+
+            public TriggerEventArgs(ModifierKeys modifierKeys)
+            {
+                ModifierKeys = modifierKeys;
+            }
+        }
     }
 }

--- a/Bearded.UI/Controls/implementations/Button.cs
+++ b/Bearded.UI/Controls/implementations/Button.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Bearded.UI.EventArgs;
+﻿using Bearded.UI.EventArgs;
 using Bearded.UI.Rendering;
 using Bearded.Utilities;
 using OpenTK.Input;
@@ -9,10 +8,7 @@ namespace Bearded.UI.Controls
 {
     public class Button : CompositeControl
     {
-        [Obsolete("Use #Triggered instead.")]
-        public event VoidEventHandler Clicked;
-
-        public event GenericEventHandler<TriggerEventArgs> Triggered;
+        public event GenericEventHandler<ClickEventArgs> Clicked;
 
         public bool IsEnabled { get; set; } = true;
 
@@ -26,24 +22,23 @@ namespace Bearded.UI.Controls
             base.MouseButtonReleased(eventArgs);
             if (eventArgs.MouseButton == MouseButton.Left && IsEnabled)
             {
-                Trigger(new TriggerEventArgs(eventArgs.ModifierKeys));
-                Clicked?.Invoke();
+                FireClickEvent(new ClickEventArgs(eventArgs.ModifierKeys));
             }
             eventArgs.Handled = true;
         }
 
-        protected void Trigger(TriggerEventArgs eventArgs)
+        protected void FireClickEvent(ClickEventArgs eventArgs)
         {
-            Triggered?.Invoke(eventArgs);
+            Clicked?.Invoke(eventArgs);
         }
 
         protected override void RenderStronglyTyped(IRendererRouter r) => r.Render(this);
 
-        public struct TriggerEventArgs
+        public readonly struct ClickEventArgs
         {
             public ModifierKeys ModifierKeys { get; }
 
-            public TriggerEventArgs(ModifierKeys modifierKeys)
+            public ClickEventArgs(ModifierKeys modifierKeys)
             {
                 ModifierKeys = modifierKeys;
             }

--- a/Bearded.UI/Controls/implementations/Button.cs
+++ b/Bearded.UI/Controls/implementations/Button.cs
@@ -22,12 +22,12 @@ namespace Bearded.UI.Controls
             base.MouseButtonReleased(eventArgs);
             if (eventArgs.MouseButton == MouseButton.Left && IsEnabled)
             {
-                FireClickEvent(new ClickEventArgs(eventArgs.ModifierKeys));
+                Click(new ClickEventArgs(eventArgs.ModifierKeys));
             }
             eventArgs.Handled = true;
         }
 
-        protected void FireClickEvent(ClickEventArgs eventArgs)
+        public void Click(ClickEventArgs eventArgs)
         {
             Clicked?.Invoke(eventArgs);
         }

--- a/Bearded.UI/Controls/implementations/Button.cs
+++ b/Bearded.UI/Controls/implementations/Button.cs
@@ -26,10 +26,15 @@ namespace Bearded.UI.Controls
             base.MouseButtonReleased(eventArgs);
             if (eventArgs.MouseButton == MouseButton.Left && IsEnabled)
             {
-                Triggered?.Invoke(new TriggerEventArgs(eventArgs.ModifierKeys));
+                Trigger(new TriggerEventArgs(eventArgs.ModifierKeys));
                 Clicked?.Invoke();
             }
             eventArgs.Handled = true;
+        }
+
+        protected void Trigger(TriggerEventArgs eventArgs)
+        {
+            Triggered?.Invoke(eventArgs);
         }
 
         protected override void RenderStronglyTyped(IRendererRouter r) => r.Render(this);


### PR DESCRIPTION
## ✨ What's this?
Changes the `Clicked` event on `Button` to have an `EventArgs` as parameter, so we can pass in the modifier keys that were held when clicking the button.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
The current `Clicked` event doesn't pass any of the event parameters down to the listeners. This means they cannot consider things such as modifier keys as part of their logic.

## 🏗 How is it done?
A new event args 

### 💥 Breaking changes
Existing subscriptions of the `Clicked` will break.

### 🔬 Why not another way?

#### Why not a new event?
Originally, a new event was added, using the following argumentation:

> Changing the event parameters of `Clicked` would be a breaking change. In addition, `Clicked` as a name is very specific towards a mouse-click. However, the method in which the button is activated is sort of an implementation detail, and future additions to the library would most likely allow activation through keyboard and controller. `Triggered` is more generic in its name, and means listeners can subscribe to the button agnostic of the method of activation.

However, this approach was rejected in review comments, and subsequently a breaking change was made 

#### Why a custom event args type?
If other arguments are needed in the future, changing the type would be a breaking change. However, adding new fields to a struct is a relatively safe change, making it easier to pass down new information in the future.

### 🦋 Side effects
A `FireClickEvent` method was added, to make extensions of `Button` possible with more complex clicking behaviour.

## 💡 Review hints
Should be a trivial change.