### PR TITLE
🐛 Don't mark list control scroll events handled without effect

### DIFF
--- a/Bearded.UI/Controls/implementations/ListControl.cs
+++ b/Bearded.UI/Controls/implementations/ListControl.cs
@@ -102,7 +102,10 @@ namespace Bearded.UI.Controls
                 onScrollUp();
             }
 
-            eventArgs.Handled = true;
+            if (offsetAfter != offsetBefore)
+            {
+                eventArgs.Handled = true;
+            }
         }
 
         public void ScrollToTop()


### PR DESCRIPTION
## ✨ What's this?
The ListControl will mark scroll events as handled, even if the list isn't scrollable (content is smaller than the container) or is already at the top or bottom of the container.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
Without this change, the ListControl would always capture all scroll events, even if it didn't have any effect. That means that if the ListControl is nested inside another scrollable control, the parent will never get the scroll events as long as the mouse cursor is hovering over the ListControl.

## 🏗 How is it done?
Only handle the event if it has an effect on the list. If not, just let it bubble back up. This is similar to how web browsers with nested scroll containers work.

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
N/A

### 🦋 Side effects
N/A

## 💡 Review hints
N/A
