### PR TITLE
🐛 Make click through list control actually click through

### DIFF
--- a/Bearded.UI/Controls/implementations/ListControl.cs
+++ b/Bearded.UI/Controls/implementations/ListControl.cs
@@ -71,9 +71,16 @@ namespace Bearded.UI.Controls
         }
 
         public static ListControl CreateClickThrough(
-                CompositeControl? listContainer = null, bool startStuckToBottom = false) =>
-            new ListControl(
-                listContainer ?? CompositeControl.CreateClickThrough(), CompositeControl.CreateClickThrough(), startStuckToBottom);
+                CompositeControl? listContainer = null, bool startStuckToBottom = false)
+        {
+            return new ListControl(
+                listContainer ?? CompositeControl.CreateClickThrough(),
+                CompositeControl.CreateClickThrough(),
+                startStuckToBottom)
+            {
+                IsClickThrough = true
+            };
+        }
 
         public ListControl(CompositeControl? listContainer = null, bool startStuckToBottom = false)
             : this(listContainer ?? new CompositeControl(), new CompositeControl(), startStuckToBottom) {}


### PR DESCRIPTION
## ✨ What's this?
Fixes a bug where the static factory method wasn't creating a list control that was itself click through.

## 🔍 Why do we want this?
It's a bug.

## 🏗 How is it done?
Set the thing.

## 💡 Review hints
Feel free to squash and merge.
