### PR TITLE
🔒 Mark classes sealed that can be sealed

### DIFF
--- a/Bearded.UI/Controls/FocusManager.cs
+++ b/Bearded.UI/Controls/FocusManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bearded.UI.Controls
 {
-    public class FocusManager
+    public sealed class FocusManager
     {
         private Control? currentFocus;
 

--- a/Bearded.UI/Controls/FocusManager.cs
+++ b/Bearded.UI/Controls/FocusManager.cs
@@ -27,7 +27,7 @@
 
             if (currentFocus.IsFocused)
                 currentFocus.Unfocus();
-            
+
             currentFocus = null;
         }
     }

--- a/Bearded.UI/Controls/RootControl.cs
+++ b/Bearded.UI/Controls/RootControl.cs
@@ -5,7 +5,7 @@ using OpenTK.Mathematics;
 
 namespace Bearded.UI.Controls
 {
-    public class RootControl : IControlParent
+    public sealed class RootControl : IControlParent
     {
         private readonly CompositeControl controls;
 
@@ -48,7 +48,7 @@ namespace Bearded.UI.Controls
                 controls.Render(r);
             }
         }
-        
+
         public ReadOnlyCollection<Control> Children => controls.Children;
         public void Add(Control child) => controls.Add(child);
         public void AddOnTopOf(Control reference, Control child) => controls.AddOnTopOf(reference, child);
@@ -58,7 +58,7 @@ namespace Bearded.UI.Controls
         {
             if (!control.IsDescendantOf(this))
                 throw new InvalidOperationException("Can only focus descendant.");
-            
+
             FocusManager.Focus(control);
 
             return true;

--- a/Bearded.UI/Controls/implementations/TextInput.cs
+++ b/Bearded.UI/Controls/implementations/TextInput.cs
@@ -105,7 +105,7 @@ namespace Bearded.UI.Controls
             InsertTextAtCursor(eventArgs.Character.ToString());
             eventArgs.Handled = true;
         }
-        
+
         public void MoveCursorToEnd()
         {
             cursorPosition = text.Length;

--- a/Bearded.UI/Core/Anchor.cs
+++ b/Bearded.UI/Core/Anchor.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bearded.UI
 {
-    public struct Anchor
+    public readonly struct Anchor
     {
         public double Percentage { get; }
         public double Offset { get; }

--- a/Bearded.UI/Core/Anchors.cs
+++ b/Bearded.UI/Core/Anchors.cs
@@ -1,6 +1,6 @@
 namespace Bearded.UI
 {
-    public struct Anchors
+    public readonly struct Anchors
     {
         public Anchor Start { get; }
         public Anchor End { get; }

--- a/Bearded.UI/Core/Frame.cs
+++ b/Bearded.UI/Core/Frame.cs
@@ -2,7 +2,7 @@
 
 namespace Bearded.UI
 {
-    public struct Frame
+    public readonly struct Frame
     {
         public Interval X { get; }
         public Interval Y { get; }

--- a/Bearded.UI/Core/HorizontalAnchors.cs
+++ b/Bearded.UI/Core/HorizontalAnchors.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bearded.UI
 {
-    public struct HorizontalAnchors
+    public readonly struct HorizontalAnchors
     {
         private readonly Anchors anchors;
 

--- a/Bearded.UI/Core/Interval.cs
+++ b/Bearded.UI/Core/Interval.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bearded.UI
 {
-    public struct Interval
+    public readonly struct Interval
     {
         public double Start { get; }
         public double Size { get; }

--- a/Bearded.UI/Core/VerticalAnchors.cs
+++ b/Bearded.UI/Core/VerticalAnchors.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bearded.UI
 {
-    public struct VerticalAnchors
+    public readonly struct VerticalAnchors
     {
         private readonly Anchors anchors;
 

--- a/Bearded.UI/EventArgs/CharEventArgs.cs
+++ b/Bearded.UI/EventArgs/CharEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bearded.UI.EventArgs
 {
-    public class CharEventArgs : RoutedEventArgs
+    public sealed class CharEventArgs : RoutedEventArgs
     {
         public char Character { get; }
 

--- a/Bearded.UI/EventArgs/KeyEventArgs.cs
+++ b/Bearded.UI/EventArgs/KeyEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace Bearded.UI.EventArgs
 {
-    public class KeyEventArgs : RoutedEventArgs
+    public sealed class KeyEventArgs : RoutedEventArgs
     {
         public Keys Key { get; }
         public ModifierKeys ModifierKeys { get; }

--- a/Bearded.UI/EventArgs/MouseButtonEventArgs.cs
+++ b/Bearded.UI/EventArgs/MouseButtonEventArgs.cs
@@ -3,7 +3,7 @@ using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Bearded.UI.EventArgs
 {
-    public class MouseButtonEventArgs : MouseEventArgs
+    public sealed class MouseButtonEventArgs : MouseEventArgs
     {
         public MouseButton MouseButton { get; }
 

--- a/Bearded.UI/Events/EventRouter.cs
+++ b/Bearded.UI/Events/EventRouter.cs
@@ -50,7 +50,7 @@ namespace Bearded.UI.Events
             tryFindPropagationPathForAnyChild(root, propagationTest, path);
             return path;
         }
-        
+
         private static bool tryFindPropagationPathForAnyChild(
             IControlParent parent, PropagationTest propagationTest, List<Control> path) =>
             parent.Children.Reverse()

--- a/Bearded.UI/Navigation/NavigationContext.cs
+++ b/Bearded.UI/Navigation/NavigationContext.cs
@@ -5,7 +5,7 @@
         public NavigationController Navigation { get; }
         public DependencyResolver Dependencies { get; }
         public T Parameters { get; }
-        
+
         public NavigationContext
             (NavigationController navigationController, DependencyResolver dependencies, T parameters)
         {

--- a/Bearded.UI/Navigation/NavigationFactories.cs
+++ b/Bearded.UI/Navigation/NavigationFactories.cs
@@ -52,7 +52,7 @@ namespace Bearded.UI.Navigation
             return (accumulators.models.ToDictionary, accumulators.views.ToDictionary);
         }
 
-        public class ModelFactoryAccumulator
+        public sealed class ModelFactoryAccumulator
         {
             private readonly Dictionary<Type, object> dict = new Dictionary<Type, object>();
 
@@ -68,7 +68,7 @@ namespace Bearded.UI.Navigation
             public IDictionary<Type, object> ToDictionary => new ReadOnlyDictionary<Type, object>(dict);
         }
 
-        public class ViewFactoryAccumulator
+        public sealed class ViewFactoryAccumulator
         {
             private readonly Dictionary<Type, object> dict = new Dictionary<Type, object>();
 

--- a/Bearded.UI/Rendering/CachedRendererRouter.cs
+++ b/Bearded.UI/Rendering/CachedRendererRouter.cs
@@ -6,7 +6,7 @@ namespace Bearded.UI.Rendering
     public class CachedRendererRouter : RendererRouter
     {
         private readonly Dictionary<Type, object> rendererCache = new Dictionary<Type, object>();
-        
+
         public CachedRendererRouter(IEnumerable<(Type type, object renderer)> renderers) : base(renderers) { }
 
         protected override IRenderer<T> GetRenderer<T>()


### PR DESCRIPTION
## ✨ What's this?
This PR marks all the classes that were never designed to be inherited from as sealed. It also does some minor clean-up around structs as well.

### 🔗 Relationships
Closes #31 

## 🔍 Why do we want this?
Either design for inheritance, or prohibit it. These classes were not designed to become base classes. If we truly care to have consumers implement their own - say - root control, then we should use an interface or specifically designed abstract base class instead.

## 🏗 How is it done?
Clicked through all the files. Where a class could be marked as sealed, I did.

### 💥 Breaking changes
Any dependency implementing subclasses of the now sealed classes will break. This is why I intend to increase the minor version next build. We're still in pre-release, so we can't change the major version.

### 🔬 Why not another way?
There's only one way to mark classes sealed 😜

### 🦋 Side effects
There are now some eventargs classes not sealed (because they're in turn inherited from), while others are. Perhaps they should all be sealed and use composition, or we should have only abstract classes for inheritance and sealed classes to actually use, or we don't care enough.

## 💡 Review hints
🤷‍♂️