### PR TITLE
⬆ Add .NET 6 to supported .NET versions

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -14,14 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -14,14 +14,13 @@ jobs:
     steps:
       # Build library and run tests
       - uses: actions/checkout@v3
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/Bearded.UI.Tests/Bearded.UI.Tests.csproj
+++ b/Bearded.UI.Tests/Bearded.UI.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Bearded.UI.Tests</RootNamespace>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>

--- a/Bearded.UI/Bearded.UI.csproj
+++ b/Bearded.UI/Bearded.UI.csproj
@@ -9,8 +9,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>ui,game,gamedev</PackageTags>
     <PackageVersion>0.0.0</PackageVersion>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
## ✨ What's this?
Includes official support for .NET 6

### 🔗 Relationships
Closed #39 

## 🔍 Why do we want this?
.NET 6 is the LTS version of .NET. See #39 for context.

## 🏗 How is it done?
Version added to the project files. GitHub actions workflow updated to include .NET 6 as well in the setup step.

### 💥 Breaking changes
None, as we continue to support existing .NET versions.

### 🔬 Why not another way?
N/A

### 🦋 Side effects
N/A

## 💡 Review hints
Double check that the checks actually succeed.
