### PR TITLE
⬆ Manually upgrade Bearded.Utilities reference.

### DIFF
--- a/Bearded.UI/Bearded.UI.csproj
+++ b/Bearded.UI/Bearded.UI.csproj
@@ -21,7 +21,7 @@
     <OutputPath>bin/Release/</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Bearded.Utilities" Version="0.2.0.393-dev" />
+    <PackageReference Include="Bearded.Utilities" Version="0.3.0-dev.3" />
     <PackageReference Include="OpenTK.Core" Version="4.7.1" />
     <PackageReference Include="OpenTK.Mathematics" Version="4.7.1" />
     <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.1" />


### PR DESCRIPTION
## ✨ What's this?
For some reason dependabot thinks we are already on the latest version. Not sure why... Maybe something related to .NET versions? This does a manual upgrade to hopefully fix that problem.

## 🔍 Why do we want this?
Bring dependabot back in line hopefully.

## 🏗 How is it done?
Manually copy the latest version into the csproj.

### 🔬 Why not another way?
We could wait for #41 to be merged first to see if that solves the issue, but that PR has been open for review for a while and... I kinda want to move this to an up-to-date dependency graph.

### 🦋 Side effects
Should be none.

## 💡 Review hints
If checks succeed, I'm confident we're good.
