### PR TITLE
👷‍♂️ Use new GitHub release action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - ignore-for-release
+    authors:
+      - dependabot
+      - octocat
+  categories:
+    - title: 💥 Breaking changes
+      labels:
+        - breaking-change
+    - title: ✨ New features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bugfixes
+      labels:
+        - bug
+        - fix
+    - title: 📝 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -42,15 +42,15 @@ jobs:
 
       # Create a GitHub release
       - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: Release ${{ env.RELEASE_VERSION }}
+          name: Release ${{ env.RELEASE_VERSION }}
           draft: false
           prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/*.nupkg"
 
       # Push the NuGet package to the package providers
       - name: Push release to NuGet


### PR DESCRIPTION
## ✨ What's this?
Updates the publish workflow to use the same workflow as `Bearded.Utilities`, and adds the required `release.yml` file,

## 🔍 Why do we want this?
This is an actually supported GitHub action, and also provides automatic release notes.

## 🏗 How is it done?
Copied from `Bearded.Utilities`.

## 💡 Review hints
There should be no changes compared to the `Bearded.Utilities` library.
