### PR TITLE
🔥 Remove .NET 5 support

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -12,5 +12,4 @@ jobs:
     with:
       dotnet-version: |
         3.1.x
-        5.0.x
         6.0.x

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -11,7 +11,6 @@ jobs:
     with:
       dotnet-version: |
         3.1.x
-        5.0.x
         6.0.x
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Bearded.UI.Tests/Bearded.UI.Tests.csproj
+++ b/Bearded.UI.Tests/Bearded.UI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Bearded.UI.Tests</RootNamespace>
-    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/Bearded.UI/Bearded.UI.csproj
+++ b/Bearded.UI/Bearded.UI.csproj
@@ -11,7 +11,7 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>ui,game,gamedev</PackageTags>
     <PackageVersion>0.0.0</PackageVersion>
-    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>


### PR DESCRIPTION
## ✨ What's this?
Removes the .NET 5 build target

## 🔍 Why do we want this?
.NET 5 is [no longer supported](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). Fewer .NET versions means fewer surfaces for bugs.

## 💡 Review hints
Depends on #101 being merged first.