### PR TITLE
🔓 Make IsClickThrough and CanBeFocused setters public

### DIFF
--- a/Bearded.UI/Controls/Control.cs
+++ b/Bearded.UI/Controls/Control.cs
@@ -49,11 +49,11 @@ namespace Bearded.UI.Controls
             }
         }
 
-        public bool IsClickThrough { get; protected set; }
+        public bool IsClickThrough { get; set; }
 
         public bool IsFocused { get; private set; }
 
-        public bool CanBeFocused { get; protected set; }
+        public bool CanBeFocused { get; set; }
 
         public void Focus()
         {


### PR DESCRIPTION
## ✨ What's this?
This makes the setters of `IsClickThrough` and `CanBeFocused` on the `Control` class public.

## 🔍 Why do we want this?
Practical experience is showing that we want to be able to use initializers to set these properties. There is also no good reason why this couldn't be made public.