### PR TITLE
Fix Button not marking Mouse Hit events as handled

### DIFF
--- a/Bearded.UI/Controls/implementations/Button.cs
+++ b/Bearded.UI/Controls/implementations/Button.cs
@@ -17,6 +17,12 @@ namespace Bearded.UI.Controls
             CanBeFocused = true;
         }
 
+        public override void MouseButtonHit(MouseButtonEventArgs eventArgs)
+        {
+            base.MouseButtonHit(eventArgs);
+            eventArgs.Handled = true;
+        }
+
         public override void MouseButtonReleased(MouseButtonEventArgs eventArgs)
         {
             base.MouseButtonReleased(eventArgs);


### PR DESCRIPTION

## ✨ What's this?
The button wouldn't mark mouse-button-hit events as handled, while it does handle the release event. This causes various problems with event propagation. Notably, I was unable to fix dragging issues because of this.